### PR TITLE
Remove ssb-friends as hard dependencie

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -291,8 +291,9 @@ function init(sbot: any, _config: any) {
         value: val,
         timestamp: val.timestamp,
       });
-      const filterPosts = makeAllowFilter(['post']);
+      if(!opts.allowlist && !opts.blocklist) { opts.allowlist = ['post'] }
 
+      const filterPosts = makeFilter(opts)
       return pull(
         pull.values([opts.root]),
         pull.asyncMap(sbot.get.bind(sbot)),

--- a/package.json
+++ b/package.json
@@ -29,9 +29,7 @@
     "pull-async": "1.0.0",
     "pull-notify": "^0.1.1",
     "ssb-server": "~15.0.2",
-    "ssb-replicate": "1.3.0",
     "ssb-backlinks": "0.7.3",
-    "ssb-friends": "3.1.7",
     "ssb-keys": "7.1.3",
     "tape": "4.9.0"
   },

--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,11 @@ Returns a pull stream that emits one thread object of messages under the root id
 
 * `opts.root`: a MsgId that identifies the root of the thread.
 * `opts.threadMaxSize`: optional number (default: Infinity). Dictates the maximum amount of messages in each returned thread object. Serves for previewing threads, particularly long ones.
+* `opts.allowlist`: optional array of strings. Dictates which messages **types** to allow as root messages, while forbidding other types.
+* `opts.blocklist`: optional array of strings. Dictates which messages **types** to forbid as root messages, while allowing other types.
+
+If `opts.allowlist` and `opts.blocklist` are not defined, 
+only messages of type **post** will be returned.
 
 ## Install
 

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,7 @@
 ## Usage
 
 Requires the backlinks plugin.
+If the ssb-friends plugin is available it will filter the messages of blocked users.
 
 ```diff
  const createSbot = require('scuttlebot/index')

--- a/test.js
+++ b/test.js
@@ -7,9 +7,7 @@ const ssbKeys = require('ssb-keys');
 const pullAsync = require('pull-async');
 
 const CreateTestSbot = require('ssb-server/index')
-  .use(require('ssb-replicate')) // required by ssb-friends
   .use(require('ssb-backlinks'))
-  .use(require('ssb-friends'))
   .use(require('./lib/index'));
 
 const lucyKeys = ssbKeys.generate();

--- a/types.ts
+++ b/types.ts
@@ -23,7 +23,7 @@ export type UpdatesOpts = {} & FilterOpts;
 export type ThreadOpts = {
   root: MsgId;
   threadMaxSize?: number;
-};
+} & FilterOpts;
 
 export type ProfileOpts = Opts & {
   id: string;


### PR DESCRIPTION
In this pull request I make two changes:
- Remove dependence on ssb-friends. In case the plugin is in sbot it uses it and if not ignores it.
- Match the threads.thread filtering api with the rest of the queries.

Both changes are documented and I changed the type definitions.

### #someone-should-do
Instead of looking for the existence of **sbot.friends.isBlocking** we need a method to get the blocks available in the different plugins and use that set instead of just one in particular.
I think that to do this it is necessary to establish a kind of contract on how to expose the filters in plugins. At the moment it exceeds my working capacity available for this pull-request.