### PR TITLE
feat: add hashtagCount method

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,16 @@ Returns a ("live") pull stream that emits a message key (strings) for every new 
 * `opts.blocklist`: optional array of strings. Dictates which messages **types** to forbid as root messages, while allowing other types.
 - `opts.following`: optional boolean (default: false). `true` means only message keys for threads created by those directly followed will be emitted. Requires `ssb-friends`.
 
+
+### `ssb.threads.hashtagCount(opts, cb)`
+
+Gets the number of public threads that match a specific hashtag `opts.hashtag`. "Hashtag" here means `msg.value.content.channel` and `msg.value.content.mentions[].link` (beginning with `#`).
+
+* `opts.hashtag`: string, required. This is a short hashtag string such as `#animals` that identifies which content categary we are interested in.
+* `opts.allowlist`: optional array of strings. Dictates which messages **types** to allow as root messages, while forbidding other types.
+* `opts.blocklist`: optional array of strings. Dictates which messages **types** to forbid as root messages, while allowing other types.
+
+
 ### `ssb.threads.hashtagSummary(opts)`
 
 Similar to `publicSummary` but limits the results to public threads that match a specific hashtag `opts.hashtag`. "Hashtag" here means `msg.value.content.channel` and `msg.value.content.mentions[].link` (beginning with `#`).

--- a/test/index.js
+++ b/test/index.js
@@ -840,6 +840,154 @@ test('threads.publicUpdates ignores replies to unknown roots', (t) => {
   );
 });
 
+test('threads.hashtagCount understands msg.value.content.channel', (t) => {
+  const ssb = CreateSSB({
+    path: fs.mkdtempSync(path.join(os.tmpdir(), 'threads-test-hashtagCount1')),
+    temp: true,
+    name: 'test9',
+    keys: lucyKeys,
+  });
+
+  pull(
+    pullAsync((cb) => {
+      ssb.db.create(
+        {
+          keys: lucyKeys,
+          content: { type: 'post', text: 'My favorite animals (thread 1)' },
+        },
+        wait(cb, 100),
+      );
+    }),
+    pull.asyncMap((rootMsg, cb) => {
+      ssb.db.create(
+        {
+          keys: lucyKeys,
+          content: {
+            type: 'post',
+            text: 'wombat (reply to thread 1)',
+            channel: 'animals',
+            root: rootMsg.key,
+          },
+        },
+        wait(cb, 100),
+      );
+    }),
+    pull.asyncMap((_, cb) => {
+      ssb.db.create(
+        {
+          keys: lucyKeys,
+          content: {
+            type: 'post',
+            text: 'My favorite animal is the wombat (thread 2)',
+            channel: 'animals',
+          },
+        },
+        wait(cb, 100),
+      );
+    }),
+    pull.drain(null, (err) => {
+      t.error(err);
+
+      ssb.threads.hashtagCount({ hashtag: 'animals' }, (err2, count) => {
+        t.error(err2);
+        t.isEqual(count, 2);
+        ssb.close(t.end);
+      });
+    }),
+  );
+});
+
+test('threads.hashtagCount understands msg.value.content.mentions', (t) => {
+  const ssb = CreateSSB({
+    path: fs.mkdtempSync(path.join(os.tmpdir(), 'threads-test-hashtagCount2')),
+    temp: true,
+    name: 'test9',
+    keys: lucyKeys,
+  });
+
+  pull(
+    pullAsync((cb) => {
+      ssb.db.create(
+        {
+          keys: lucyKeys,
+          content: { type: 'post', text: 'My favorite animals (thread 1)' },
+        },
+        wait(cb, 100),
+      );
+    }),
+    pull.asyncMap((rootMsg, cb) => {
+      ssb.db.create(
+        {
+          keys: lucyKeys,
+          content: {
+            type: 'post',
+            text: 'wombat (reply to thread 1)',
+            mentions: [{ link: '#animals' }],
+            root: rootMsg.key,
+          },
+        },
+        wait(cb, 100),
+      );
+    }),
+    pull.asyncMap((_, cb) => {
+      ssb.db.create(
+        {
+          keys: lucyKeys,
+          content: {
+            type: 'post',
+            text: 'My favorite animal is the wombat (thread 2)',
+            mentions: [{ link: '#animals' }],
+          },
+        },
+        wait(cb, 100),
+      );
+    }),
+    pull.drain(null, (err) => {
+      t.error(err);
+
+      ssb.threads.hashtagCount({ hashtag: 'animals' }, (err2, count) => {
+        t.error(err2);
+        t.isEqual(count, 2);
+        ssb.close(t.end);
+      });
+    }),
+  );
+});
+
+test('threads.hashtagCount input is case-insensitive', (t) => {
+  const ssb = CreateSSB({
+    path: fs.mkdtempSync(path.join(os.tmpdir(), 'threads-test-hashtagCount3')),
+    temp: true,
+    name: 'test9',
+    keys: lucyKeys,
+  });
+
+  pull(
+    pullAsync((cb) => {
+      ssb.db.create(
+        {
+          keys: lucyKeys,
+          content: {
+            type: 'post',
+            text: 'My favorite animal is the wombat',
+            mentions: [{ link: '#animals' }],
+          },
+        },
+        wait(cb, 100),
+      );
+    }),
+    pull.drain(null, (err) => {
+      t.error(err);
+
+      ssb.threads.hashtagCount({ hashtag: 'ANIMALS' }, (err2, count) => {
+        t.error(err2);
+        t.isEqual(count, 1);
+        ssb.close(t.end);
+      });
+    }),
+  );
+});
+
 test('threads.hashtagSummary understands msg.value.content.channel', (t) => {
   const ssb = CreateSSB({
     path: fs.mkdtempSync(path.join(os.tmpdir(), 'threads-test-hashtag1')),


### PR DESCRIPTION
Adds a method to return the number of public threads that match the specified hashtag string.

See https://gitlab.com/staltz/manyverse/-/issues/2115 for additional context