### PR TITLE
feat: add recentHashtags method

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,13 @@ Returns a pull stream that emits thread objects of private conversations.
 * `opts.allowlist`: optional array of strings. Dictates which messages **types** to allow as root messages, while forbidding other types.
 * `opts.blocklist`: optional array of strings. Dictates which messages **types** to forbid as root messages, while allowing other types.
 
+### `ssb.threads.recentHashtags(opts, cb)`
+
+Call the callback with an array of hashtags labels of length `opts.limit` (defaults to 10 if unspecified). "hashtagLabel" here means `msg.value.content.channel` and `msg.value.content.mentions[].link` (omitting the `#`). Results are ordered with the most recent first, as determined by the log.
+
+* `opts.limit`: number, required. Limits the number of results that are returned.
+* `opts.preserveCase`: optional boolean, default `false`. Return the hashtag labels with their original casing. By default, all hashtag labels are converted to lowercase but there are times when it's preferable to preserve the casing as seen in the log.
+
 ### `ssb.threads.privateUpdates(opts)`
 
 Returns a ("live") pull stream that emits the message key (string) for thread roots every time there is a new reply or root, and that passes the (optional) allowlist or blocklist.

--- a/src/index.ts
+++ b/src/index.ts
@@ -605,9 +605,7 @@ class threads {
             result.set(lowercaseWithoutHashtag, withoutHashtag);
           }
         } else if (Array.isArray(mentions)) {
-          // Assumes `mentions` goes from oldest to most recent
-          // so we want to process them in reverse order
-          for (const mention of mentions.reverse()) {
+          for (const mention of mentions) {
             const withoutHashtag = withoutLeadingHashtag(mention.link);
             const lowercaseWithoutHashtag = withoutHashtag.toLocaleLowerCase();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -599,8 +599,10 @@ class threads {
           const lowercaseWithoutHashtag = withoutHashtag.toLocaleLowerCase();
 
           // Since the messages received are descending,
-          // we don't want to update the value for associated key if it already exists
-          // because we want the keep the most recent variation of the hashtag (accounts for casing)
+          // we don't want to update the value for
+          // associated key if it already exists
+          // because we want the keep the most recent
+          // variation of the hashtag (accounts for casing)
           if (!result.has(lowercaseWithoutHashtag)) {
             result.set(lowercaseWithoutHashtag, withoutHashtag);
           }
@@ -610,8 +612,10 @@ class threads {
             const lowercaseWithoutHashtag = withoutHashtag.toLocaleLowerCase();
 
             // Since the messages received are descending,
-            // we don't want to update the value for associated key if it already exists
-            // because we want the keep the most recent variation of the hashtag (accounts for casing)
+            // we don't want to update the value for
+            // associated key if it already exists
+            // because we want the keep the most recent
+            // variation of the hashtag (accounts for casing)
             if (!result.has(lowercaseWithoutHashtag)) {
               result.set(lowercaseWithoutHashtag, withoutHashtag);
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {
   HashtagOpts,
   HashtagUpdatesOpts,
   HashtagsMatchingOpts,
+  RecentHashtagsOpts,
 } from './types';
 const pull = require('pull-stream');
 const cat = require('pull-cat');
@@ -37,8 +38,11 @@ const {
   hasFork,
   toPullStream,
 } = require('ssb-db2/operators');
-import HashtagsPlugin = require('./hashtags');
-const hasHashtag = HashtagsPlugin.operator;
+
+import HashtagsPlugin from './hashtags';
+
+const hasHashtag = HashtagsPlugin.hasHashtagOperator;
+const hasSomeHashtag = HashtagsPlugin.hasSomeHashtagOperator;
 
 type CB<T> = (err: any, val?: T) => void;
 
@@ -91,6 +95,11 @@ function hasNoBacklinks(msg: Msg<any>): boolean {
 
 function notNull(x: any): boolean {
   return x !== null;
+}
+
+// Strip leading # from hashtag string
+function withoutLeadingHashtag(s: string) {
+  return s.startsWith('#') ? s.slice(1) : s;
 }
 
 function makeFilterOperator(opts: FilterOpts): any {
@@ -562,6 +571,63 @@ class threads {
       const hashtagsPlugin: HashtagsPlugin = this.ssb.db.getIndex('hashtags');
       hashtagsPlugin.getMatchingHashtags(opts.query, opts.limit || 10, cb);
     });
+  };
+
+  @muxrpc('async')
+  public recentHashtags = (opts: RecentHashtagsOpts, cb: CB<Array<string>>) => {
+    if (typeof opts.limit !== 'number' || opts.limit <= 0)
+      return cb(new Error('Limit must be number greater than 0'));
+
+    const preserveCase = !!opts.preserveCase;
+
+    // completely normalized hashtag (no leading # and lowercase) -> partially normalized (no leading #)
+    const result = new Map<string, string>();
+
+    return pull(
+      this.ssb.db.query(
+        where(and(isPublic(), hasSomeHashtag())),
+        descending(),
+        batch(BATCH_SIZE),
+        toPullStream(),
+      ),
+      this.removeMessagesFromBlocked,
+      pull.through((msg: Msg<any>) => {
+        const { channel, mentions } = msg.value.content;
+
+        if (channel) {
+          const withoutHashtag = withoutLeadingHashtag(channel);
+          const lowercaseWithoutHashtag = withoutHashtag.toLocaleLowerCase();
+
+          // Since the messages received are descending,
+          // we don't want to update the value for associated key if it already exists
+          // because we want the keep the most recent variation of the hashtag (accounts for casing)
+          if (!result.has(lowercaseWithoutHashtag)) {
+            result.set(lowercaseWithoutHashtag, withoutHashtag);
+          }
+        } else if (Array.isArray(mentions)) {
+          // Assumes `mentions` goes from oldest to most recent
+          // so we want to process them in reverse order
+          for (const mention of mentions.reverse()) {
+            const withoutHashtag = withoutLeadingHashtag(mention.link);
+            const lowercaseWithoutHashtag = withoutHashtag.toLocaleLowerCase();
+
+            // Since the messages received are descending,
+            // we don't want to update the value for associated key if it already exists
+            // because we want the keep the most recent variation of the hashtag (accounts for casing)
+            if (!result.has(lowercaseWithoutHashtag)) {
+              result.set(lowercaseWithoutHashtag, withoutHashtag);
+            }
+
+            if (result.size === opts.limit) break;
+          }
+        }
+      }),
+      // Keep taking values until the result size === limit
+      pull.take(() => result.size < opts.limit),
+      pull.onEnd(() => {
+        cb(null, Array.from(preserveCase ? result.values() : result.keys()));
+      }),
+    );
   };
 
   @muxrpc('source')

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,3 +60,8 @@ export type HashtagsMatchingOpts = {
   query: string;
   limit?: number;
 };
+
+export type RecentHashtagsOpts = {
+  limit: number;
+  preserveCase?: boolean;
+};

--- a/test/recentHashtags.test.js
+++ b/test/recentHashtags.test.js
@@ -1,0 +1,337 @@
+const test = require('tape');
+const pull = require('pull-stream');
+const pullAsync = require('pull-async');
+const ssbKeys = require('ssb-keys');
+const p = require('util').promisify;
+const Testbot = require('./testbot');
+const wait = require('./wait');
+
+const andrewKeys = ssbKeys.generate(null, 'andrew');
+const brianKeys = ssbKeys.generate(null, 'brian');
+
+test('threads.recentHashtags errors on bad limit option', (t) => {
+  const ssb = Testbot({ keys: andrewKeys });
+
+  ssb.threads.recentHashtags({ limit: 0 }, (err) => {
+    t.ok(err);
+
+    ssb.threads.recentHashtags({ limit: -1 }, (err2) => {
+      t.ok(err2);
+      ssb.close(t.end);
+    });
+  });
+});
+
+test('threads.recentHashtags returns empty result when no messages with hashtags exist', (t) => {
+  const ssb = Testbot({ keys: andrewKeys });
+
+  pull(
+    pullAsync((cb) => {
+      ssb.db.create(
+        {
+          keys: andrewKeys,
+          content: {
+            type: 'post',
+            text: 'My favorite animals (thread 1)',
+          },
+        },
+        wait(cb, 100),
+      );
+    }),
+    pull.asyncMap((rootMsg, cb) => {
+      ssb.db.create(
+        {
+          keys: andrewKeys,
+          content: {
+            type: 'post',
+            text: 'I like wombats (reply to thread 1)',
+            root: rootMsg,
+          },
+        },
+        wait(cb, 100),
+      );
+    }),
+    pull.asyncMap((_, cb) => {
+      ssb.db.create(
+        {
+          keys: brianKeys,
+          content: {
+            type: 'post',
+            text: 'My favorite animal is the beaver (thread 2)',
+          },
+        },
+        wait(cb, 100),
+      );
+    }),
+    pull.drain(null, (err) => {
+      t.error(err);
+
+      ssb.threads.recentHashtags({ limit: 10 }, (err2, hashtags) => {
+        t.error(err2);
+        t.deepEquals(hashtags, []);
+        ssb.close(t.end);
+      });
+    }),
+  );
+});
+
+test('threads.recentHashtags basic case works', (t) => {
+  const ssb = Testbot({ keys: andrewKeys });
+
+  pull(
+    pullAsync((cb) => {
+      ssb.db.create(
+        {
+          keys: andrewKeys,
+          content: {
+            type: 'post',
+            text: 'My favorite animals (thread 1)',
+            channel: 'animals',
+          },
+        },
+        wait(cb, 100),
+      );
+    }),
+    pull.asyncMap((rootMsg, cb) => {
+      ssb.db.create(
+        {
+          keys: andrewKeys,
+          content: {
+            type: 'post',
+            text: 'I like #wombats (reply to thread 1)',
+            mentions: [{ link: '#wombats' }],
+            root: rootMsg,
+          },
+        },
+        wait(cb, 100),
+      );
+    }),
+    pull.asyncMap((_, cb) => {
+      ssb.db.create(
+        {
+          keys: brianKeys,
+          content: {
+            type: 'post',
+            text: 'My favorite animal is the #beaver (thread 2)',
+            mentions: [{ link: '#beaver' }],
+          },
+        },
+        wait(cb, 100),
+      );
+    }),
+    pull.drain(null, (err) => {
+      t.error(err);
+
+      ssb.threads.recentHashtags({ limit: 10 }, (err2, hashtags) => {
+        t.error(err2);
+        t.deepEquals(hashtags, ['beaver', 'wombats', 'animals']);
+        ssb.close(t.end);
+      });
+    }),
+  );
+});
+
+test('threads.recentHashtags respects limit opt', (t) => {
+  const ssb = Testbot({ keys: andrewKeys });
+
+  pull(
+    pullAsync((cb) => {
+      ssb.db.create(
+        {
+          keys: andrewKeys,
+          content: {
+            type: 'post',
+            text: 'My favorite animals (thread 1)',
+            channel: 'animals',
+          },
+        },
+        wait(cb, 100),
+      );
+    }),
+    pull.asyncMap((rootMsg, cb) => {
+      ssb.db.create(
+        {
+          keys: andrewKeys,
+          content: {
+            type: 'post',
+            text: 'I like #wombats (reply to thread 1)',
+            mentions: [{ link: '#wombats' }],
+            root: rootMsg,
+          },
+        },
+        wait(cb, 100),
+      );
+    }),
+    pull.asyncMap((_, cb) => {
+      ssb.db.create(
+        {
+          keys: brianKeys,
+          content: {
+            type: 'post',
+            text: 'My favorite animal is the #beaver (thread 2)',
+            mentions: [{ link: '#beaver' }],
+          },
+        },
+        wait(cb, 100),
+      );
+    }),
+    pull.drain(null, (err) => {
+      t.error(err);
+
+      ssb.threads.recentHashtags({ limit: 2 }, (err2, hashtags) => {
+        t.error(err2);
+        t.deepEquals(hashtags, ['beaver', 'wombats']);
+        ssb.close(t.end);
+      });
+    }),
+  );
+});
+
+test('threads.recentHashtags respects preserveCase opt', (t) => {
+  const ssb = Testbot({ keys: andrewKeys });
+
+  pull(
+    pullAsync((cb) => {
+      ssb.db.create(
+        {
+          keys: andrewKeys,
+          content: {
+            type: 'post',
+            text: 'My favorite animals (thread 1)',
+            channel: 'animals',
+          },
+        },
+        wait(cb, 100),
+      );
+    }),
+    pull.asyncMap((rootMsg, cb) => {
+      ssb.db.create(
+        {
+          keys: andrewKeys,
+          content: {
+            type: 'post',
+            text: 'I like #wombats (reply to thread 1)',
+            mentions: [{ link: '#wombats' }],
+            root: rootMsg,
+          },
+        },
+        wait(cb, 100),
+      );
+    }),
+    pull.asyncMap((_, cb) => {
+      ssb.db.create(
+        {
+          keys: brianKeys,
+          content: {
+            type: 'post',
+            text: 'My favorite animal is the #BlueBeaver (thread 2)',
+            mentions: [{ link: '#BlueBeaver' }],
+          },
+        },
+        wait(cb, 100),
+      );
+    }),
+    pull.drain(null, (err) => {
+      t.error(err);
+
+      ssb.threads.recentHashtags(
+        { limit: 1, preserveCase: false },
+        (err2, hashtags) => {
+          t.error(err2);
+          t.deepEquals(hashtags, ['bluebeaver']);
+
+          ssb.threads.recentHashtags(
+            { limit: 1, preserveCase: true },
+            (err3, hashtags2) => {
+              t.error(err3);
+              t.deepEquals(hashtags2, ['BlueBeaver']);
+              ssb.close(t.end);
+            },
+          );
+        },
+      );
+    }),
+  );
+});
+
+test('threads.recentHashtags returns proper ordering when a relevant msg has many mention links', (t) => {
+  const ssb = Testbot({ keys: andrewKeys });
+
+  pull(
+    pullAsync((cb) => {
+      ssb.db.create(
+        {
+          keys: andrewKeys,
+          content: {
+            type: 'post',
+            text: '#Animals I like include #wombats and #beavers',
+            mentions: [
+              { link: '#animals' },
+              { link: '#wombats' },
+              { link: '#beavers' },
+            ],
+          },
+        },
+        cb,
+      );
+    }),
+    pull.drain(null, (err) => {
+      t.error(err);
+
+      ssb.threads.recentHashtags(
+        { limit: 10, preserveCase: true },
+        (err2, hashtags) => {
+          t.error(err2);
+          t.deepEquals(hashtags, ['beavers', 'wombats', 'animals']);
+          ssb.close(t.end);
+        },
+      );
+    }),
+  );
+});
+
+test('threads.recentHashtags returns most recently seen variation when preserveCase opt is true', (t) => {
+  const ssb = Testbot({ keys: andrewKeys });
+
+  pull(
+    pullAsync((cb) => {
+      ssb.db.create(
+        {
+          keys: andrewKeys,
+          content: {
+            type: 'post',
+            text: 'My favorite animals (thread 1)',
+            channel: 'animals',
+          },
+        },
+        wait(cb, 100),
+      );
+    }),
+    pull.asyncMap((rootMsg, cb) => {
+      ssb.db.create(
+        {
+          keys: brianKeys,
+          content: {
+            type: 'post',
+            text: '#Animals I like include wombats (reply to thread 1)',
+            mentions: [{ link: '#Animals' }],
+            root: rootMsg,
+          },
+        },
+        wait(cb, 100),
+      );
+    }),
+    pull.drain(null, (err) => {
+      t.error(err);
+
+      ssb.threads.recentHashtags(
+        { limit: 10, preserveCase: true },
+        (err2, hashtags) => {
+          t.error(err2);
+          t.deepEquals(hashtags, ['Animals']);
+          ssb.close(t.end);
+        },
+      );
+    }),
+  );
+});

--- a/test/recentHashtags.test.js
+++ b/test/recentHashtags.test.js
@@ -272,7 +272,7 @@ test('threads.recentHashtags handles messages with many mentions links', (t) => 
             ],
           },
         },
-        cb,
+        wait(cb, 100),
       );
     }),
     pull.asyncMap((_, cb) => {
@@ -285,7 +285,7 @@ test('threads.recentHashtags handles messages with many mentions links', (t) => 
             mentions: [{ link: '#p4p' }, { link: '#p2p' }],
           },
         },
-        cb,
+        wait(cb, 100),
       );
     }),
     pull.drain(null, (err) => {


### PR DESCRIPTION
See https://gitlab.com/staltz/manyverse/-/issues/1687 for more context

Questions:

- Does it make sense to include the `preserveCase` option to return the hashtags with the casing as seen in the logs? Although the relevant message fields should have lowercased values when published, I figured it was useful to have such a feature because:

  1. Anyone could publish a message where the value doesn't adhere to that e.g. #FooBar 

  2. From an application standpoint, it may be desirable to keep the original casing because it's easier to go from `FooBar -> foobar` instead of `foobar -> FooBar`. Saw a tweet/toot recently that explained that people should use Pascal casing for their hashtags for a11y reasons, which i found interesting and prompted this point